### PR TITLE
Added "rom" command line argument

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,6 +4,24 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -51,6 +69,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gleam 0.4.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "clap"
+version = "2.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -177,6 +209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "gb_emulator"
 version = "0.1.0"
 dependencies = [
+ "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glium 0.20.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -342,6 +375,14 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -369,8 +410,13 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "strsim"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "tempfile"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -381,8 +427,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "token_store"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "vec_map"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -443,7 +517,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memmap 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-client 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "wayland-protocols 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -508,6 +582,8 @@ dependencies = [
 
 [metadata]
 "checksum android_glue 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "000444226fcff248f2bc4c7625be32c63caccfecc2723a2b9f78a7487a49c407"
+"checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum atty 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "2fc4a1aa4c24c0718a250f0681885c1af91419d242f29eb8f2ab28502d80dbd1"
 "checksum backtrace 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbbf59b1c43eefa8c3ede390fcc36820b4999f7914104015be25025e0d62af2"
 "checksum backtrace-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "44585761d6161b0f57afc49482ab6bd067e4edef48c12a152c237eb0203f7661"
 "checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
@@ -515,6 +591,7 @@ dependencies = [
 "checksum cc 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2b4911e4bdcb4100c7680e7e854ff38e23f1b34d4d9e079efae3da2801341ffc"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cgl 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "86765cb42c2a2c497e142af72517c1b4d7ae5bb2f25dfa77a5c69642f2342d89"
+"checksum clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f0f16b89cbb9ee36d87483dc939fe9f1e13c05898d56d7b230a0d4dff033a536"
 "checksum cocoa 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac0d785ff4faf0ff23d7b5561346bb50dc7ef9a11cb0e65e07ef776b7752938f"
 "checksum cocoa 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b0c23085dde1ef4429df6e5896b89356d35cdd321fb43afe3e378d010bb5adc6"
 "checksum core-foundation 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "8047f547cd6856d45b1cdd75ef8d2f21f3d0e4bf1dab0a0041b0ae9a5dda9c0e"
@@ -548,12 +625,18 @@ dependencies = [
 "checksum pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3a8b4c6b8165cd1a1cd4b9b120978131389f64bdaf456435caa41e630edba903"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum remove_dir_all 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfc5b3ce5d5ea144bb04ebd093a9e14e9765bcfec866aecda9b6dec43b3d1e24"
 "checksum rustc-demangle 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "11fb43a206a04116ffd7cfcf9bcb941f8eb6cc7ff667272246b0a1c74259a3cb"
 "checksum shared_library 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "8254bf098ce4d8d7cc7cc6de438c5488adc5297e5b7ffef88816c0a91bd289c1"
 "checksum smallvec 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44db0ecb22921ef790d17ae13a3f6d15784183ff5f2a01aa32098c7498d2b4b9"
-"checksum tempfile 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "439d9a7c00f98b1b5ee730039bf5b1f9203d508690e3c76b509e7ad59f8f7c99"
+"checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
+"checksum tempfile 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "47776f63b85777d984a50ce49d6b9e58826b6a3766a449fc95bc66cd5663c15b"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum textwrap 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c0b59b6b4b44d867f1370ef1bd91bfb262bf07bf0ae65c202ea2fbc16153b693"
 "checksum token_store 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a686838375fc11103b9c1529c6508320b7bd5e2401cd62831ca51b3e82e61849"
+"checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
+"checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
 "checksum wayland-client 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "2b90adf943117ee4930d7944fe103dcb6f36ba05421f46521cb5adbf6bf0fbc8"
 "checksum wayland-kbd 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4fe0fb1c9917da9529d781659e456d84a693d74fe873d1658109758444616f76"
 "checksum wayland-protocols 0.12.5 (registry+https://github.com/rust-lang/crates.io-index)" = "fb5942dd2fc79d934db437c9ea3aabffceb49b546046ea453bcba531005e5537"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,4 @@ authors = ["Guilherme Chichanoski <guilherme.chichanoski@gmail.com>"]
 
 [dependencies]
 glium = "*"
+clap = "2.31.2"

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -91,19 +91,15 @@ enum Operand {
     AddressU8(u16),
     AddressU16(u16),
     Register(Register),
-    RegisterAddressU8(Register), // Decay to AddressU8
+    RegisterAddressU8(Register),  // Decay to AddressU8
     RegisterAddressU16(Register), // Decay to AddressU16
 }
 
 impl Operand {
     fn get(&self, cpu: &CPU) -> i16 {
         match self {
-            Operand::AddressU8(address) => {
-                cpu.memory.get_byte(*address).unwrap() as i16
-            }
-            Operand::AddressU16(address) => {
-                cpu.memory.get_word(*address).unwrap()
-            }
+            Operand::AddressU8(address) => cpu.memory.get_byte(*address).unwrap() as i16,
+            Operand::AddressU16(address) => cpu.memory.get_word(*address).unwrap(),
             Operand::Register(register) => register.read(cpu),
             Operand::RegisterAddressU8(register) => {
                 let result = register.read(cpu);
@@ -146,9 +142,7 @@ impl fmt::Display for Operand {
             Operand::AddressU16(address) => write!(f, "({:04X})", address),
             Operand::Register(register) => register.fmt(f),
             Operand::RegisterAddressU8(register) => write!(f, "({})", register),
-            Operand::RegisterAddressU16(register) => {
-                write!(f, "({})", register)
-            }
+            Operand::RegisterAddressU16(register) => write!(f, "({})", register),
         }
     }
 }
@@ -171,10 +165,9 @@ impl Instructions {
     fn execute(&self, cpu: &mut CPU) {
         let result: i16;
         match self {
-            Instructions::Undefined { opcode } => panic!(
-                "{:02X}: Not identified on Address 0x{:04X}",
-                opcode, cpu.pc
-            ),
+            Instructions::Undefined { opcode } => {
+                panic!("{:02X}: Not identified on Address 0x{:04X}", opcode, cpu.pc)
+            }
             Instructions::Nop => {}
             Instructions::Add { op1, op2 } => {
                 result = op2.get(cpu);
@@ -402,16 +395,12 @@ impl Instructions {
 impl fmt::Display for Instructions {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Instructions::Undefined { opcode } => {
-                write!(f, "Undefined {:04X}", opcode)
-            }
+            Instructions::Undefined { opcode } => write!(f, "Undefined {:04X}", opcode),
             Instructions::Nop => write!(f, "Nop"),
             Instructions::Add { op1, op2 } => write!(f, "Add {}, {}", op1, op2),
             Instructions::Xor { op1, op2 } => write!(f, "Xor {}, {}", op1, op2),
             Instructions::Jp { op } => write!(f, "Jp {}", op),
-            Instructions::Load { op1, op2 } => {
-                write!(f, "Load {}, {}", op1, op2)
-            }
+            Instructions::Load { op1, op2 } => write!(f, "Load {}, {}", op1, op2),
             Instructions::Inc { op } => write!(f, "Inc {}", op),
             Instructions::Dec { op } => write!(f, "Dec {}", op),
             Instructions::Sla { op } => write!(f, "Sla {}", op),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,10 @@
+extern crate clap;
 extern crate glium;
+
+use clap::{App, Arg};
 
 use glium::glutin;
 use glium::Surface;
-use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 
@@ -10,11 +12,25 @@ mod cpu;
 mod memory;
 
 fn main() {
-    // Obtem os argumentos do terminal
-    let args: Vec<String> = env::args().collect();
+    let matches = App::new("RustBoy")
+        .version("0.1.0")
+        .author("Guilherme Chichanoski <guilherme.chichanoski@gmail.com>")
+        .about("A GameBoy Emulator.")
+        .arg(
+            Arg::with_name("rom")
+                .short("r")
+                .long("rom")
+                .help("ROM file to load")
+                .takes_value(true)
+                .required(true),
+        )
+        .get_matches();
+
+    // It's safe to unwrap here because this argument is required.
+    let rom_path = matches.value_of("rom").unwrap();
 
     // Abre o arquivo
-    let mut rom_file = match File::open(&args[1]) {
+    let mut rom_file = match File::open(rom_path) {
         Ok(file) => file,
         Err(err) => panic!("Deu bosta na leitura do arquivo: {}", err),
     };

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -12,9 +12,7 @@ struct TranslatedAddress {
 }
 
 impl Memory {
-    fn translate_address(
-        address: u16,
-    ) -> Result<TranslatedAddress, &'static str> {
+    fn translate_address(address: u16) -> Result<TranslatedAddress, &'static str> {
         if address == 0 {
             Err("Memory must be higher than zero")
         } else if address < 0x8000 {
@@ -30,9 +28,7 @@ impl Memory {
     pub fn get_byte(&self, address: u16) -> Result<i8, &'static str> {
         let translate_address = Memory::translate_address(address)?;
         match translate_address.section {
-            Section::Rom => {
-                Ok(self.rom[translate_address.address as usize] as i8)
-            }
+            Section::Rom => Ok(self.rom[translate_address.address as usize] as i8),
             _ => Err("Not mapped yet"),
         }
     }
@@ -44,8 +40,7 @@ impl Memory {
                 let l_data = self.get_byte(address).unwrap();
                 let m_data = self.get_byte(address + 1).unwrap();
 
-                let data =
-                    (((m_data as u16) << 8) | (l_data as u8) as u16) as i16;
+                let data = (((m_data as u16) << 8) | (l_data as u8) as u16) as i16;
 
                 Ok(data)
             }
@@ -56,9 +51,7 @@ impl Memory {
     pub fn set_byte(&mut self, address: u16, value: i8) {
         let translate_address = Memory::translate_address(address).unwrap();
         match translate_address.section {
-            Section::Rom => {
-                self.rom[translate_address.address as usize] = value as u8
-            }
+            Section::Rom => self.rom[translate_address.address as usize] = value as u8,
         };
     }
 
@@ -66,8 +59,7 @@ impl Memory {
         let translate_address = Memory::translate_address(address).unwrap();
         match translate_address.section {
             Section::Rom => {
-                self.rom[translate_address.address as usize] =
-                    (value >> 8) as u8;
+                self.rom[translate_address.address as usize] = (value >> 8) as u8;
                 self.rom[translate_address.address as usize] = value as u8;
             }
         };

--- a/src/memory.rs
+++ b/src/memory.rs
@@ -13,7 +13,7 @@ struct TranslatedAddress {
 
 impl Memory {
     fn translate_address(address: u16) -> Result<TranslatedAddress, &'static str> {
-        if address == 0 {
+        if address <= 0 {
             Err("Memory must be higher than zero")
         } else if address < 0x8000 {
             Ok(TranslatedAddress {


### PR DESCRIPTION
Adicionei um argumento chamado "rom" para passar o caminho do binário a ser executado.

Exemplo: `gb_emulator -r roms/Tetris.gb` ou `gb_emulator --rom roms/Tetris.gb`.

Para fazer isso adicionei um biblioteca chamada [clap](https://crates.io/crates/clap), ela é bem poderosa deixando fácil de adicionar novos parâmetros no futuro.

- Argumento "rom" para passar o caminho do binário a ser executado;
- Garantir que endereço da memória a ser acessada é não negativo.