### PR TITLE
overflowing_literals false positive

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -526,7 +526,7 @@ impl CPU {
             b: 0x00,
             c: 0x13,
             d: 0x00,
-            e: 0xD8,
+            e: 0xD8_u8 as i8,
             h: 0x01,
             l: 0x4D,
             fz: false,


### PR DESCRIPTION
In a future version of Rust the `overflowing_literals` lint will become deny by default. See rust-lang/rust#55632. When checking for breakage in crates uploaded to crates.io it was discovered that this crate will no longer compile thanks to this lint. The error produced is [here](https://crater-reports.s3.amazonaws.com/pr-55632/try%23dc13be39fae8d4c607889b27de374b52586485a3/gh/GChicha.RustBoy/log.txt). This PR should fix the false positive.